### PR TITLE
Improve invocation remembering for reused methods

### DIFF
--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -35,6 +35,16 @@ class TestDouble(object):
     pass
 
 
+class RememberedInvocationBuilder(object):
+    def __init__(self, mock, method_name):
+        self.mock = mock
+        self.method_name = method_name
+
+    def __call__(self, *params, **named_params):
+        invoc = invocation.RememberedInvocation(self.mock, self.method_name)
+        return invoc(*params, **named_params)
+
+
 class mock(TestDouble):
     def __init__(self, mocked_obj=None, strict=True):
         self.invocations = []
@@ -58,7 +68,7 @@ class mock(TestDouble):
         if self.verification is not None:
             return invocation.VerifiableInvocation(self, method_name)
 
-        return invocation.RememberedInvocation(self, method_name)
+        return RememberedInvocationBuilder(self, method_name)
 
     def remember(self, invocation):
         self.invocations.insert(0, invocation)

--- a/mockito_test/verifications_test.py
+++ b/mockito_test/verifications_test.py
@@ -86,6 +86,15 @@ class VerificationTestBase(TestBase):
 
         self.verification_function(self.mock, times=3).foo()
 
+    def testVerifiesMultipleCallsWhenMethodUsedAsFunction(self):
+        self.mock = mock()
+        f = self.mock.foo
+        f(1, 2)
+        f('foobar')
+
+        self.verification_function(self.mock).foo(1, 2)
+        self.verification_function(self.mock).foo('foobar')
+
     def testFailsVerificationOfMultipleCalls(self):
         self.mock = mock()
         self.mock.foo()


### PR DESCRIPTION
When you get attribute from mock, it returns RememberedInvocation
instance that remembers arguments with wich it was called. But in
Python you can actually store/pass this method as a callable and
use it multiple times. Every call to such method overwrites
remembered invocation parameters instead of accumulating
invocations:

    method = mock.method
    method(1, 2)
    method(2, 3)

    verify(mock).method(1, 2)
    verify(mock).method(2, 3)

Instead current implementation will produce results that can
satisfy following:

    verify(mock, times=2).method(2, 3)

This patch fixes this behavior by returning a special callable
that generates new RememberedInvocation on each call to it.