### PR TITLE
Add API to clear all mock invocations

### DIFF
--- a/mockito/__init__.py
+++ b/mockito/__init__.py
@@ -22,7 +22,7 @@
 
 
 from .mockito import (
-    when, when2, patch, expect, unstub, verify, verifyNoMoreInteractions,
+    when, when2, patch, expect, unstub, clear, verify, verifyNoMoreInteractions,
     verifyZeroInteractions, verifyNoUnwantedInteractions,
     verifyStubbedInvocationsAreUsed,
     ArgumentError)
@@ -39,7 +39,7 @@ __version__ = '1.0.13-dev'
 __all__ = ['mock', 'spy', 'spy2', 'when', 'when2', 'patch', 'expect', 'verify',
            'verifyNoMoreInteractions', 'verifyZeroInteractions',
            'verifyNoUnwantedInteractions', 'verifyStubbedInvocationsAreUsed',
-           'inorder', 'unstub',
+           'inorder', 'unstub', 'clear',
            'VerificationError', 'ArgumentError',
            'any',       # compatibility
            'contains',  # compatibility

--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -62,6 +62,8 @@ class Mock(object):
     def finish_stubbing(self, stubbed_invocation):
         self.stubbed_invocations.appendleft(stubbed_invocation)
 
+    def clear_invocations(self):
+        self.invocations = deque()
 
     # STUBBING
 

--- a/mockito/mockito.py
+++ b/mockito/mockito.py
@@ -331,6 +331,13 @@ def unstub(*objs):
         mock_registry.unstub_all()
 
 
+def clear(*objs):
+    """Clears all invocations from a mock."""
+    for obj in objs:
+        theMock = _get_mock_or_raise(obj)
+        theMock.clear_invocations()
+
+
 def verifyNoMoreInteractions(*objs):
     verifyNoUnwantedInteractions(*objs)
 

--- a/mockito/tests/verifications_test.py
+++ b/mockito/tests/verifications_test.py
@@ -22,7 +22,7 @@ import pytest
 
 from .test_base import TestBase
 from mockito import (
-    mock, verify, inorder, VerificationError, ArgumentError,
+    mock, when, verify, clear, inorder, VerificationError, ArgumentError,
     verifyNoMoreInteractions, verifyZeroInteractions,
     verifyNoUnwantedInteractions, verifyStubbedInvocationsAreUsed,
     any)
@@ -318,6 +318,31 @@ class VerifyZeroInteractionsTest(TestBase):
         theMock.foo()
         self.assertRaises(
             VerificationError, verifyNoMoreInteractions, theMock)
+
+
+class ClearInvocationsTest(TestBase):
+    def testClearsInvocations(self):
+        theMock1 = mock()
+        theMock2 = mock()
+        theMock1.do_foo()
+        theMock2.do_bar()
+
+        self.assertRaises(VerificationError, verifyZeroInteractions, theMock1)
+        self.assertRaises(VerificationError, verifyZeroInteractions, theMock2)
+
+        clear(theMock1, theMock2)
+
+        verifyZeroInteractions(theMock1)
+        verifyZeroInteractions(theMock2)
+
+    def testPreservesStubs(self):
+        theMock = mock()
+        when(theMock).do_foo().thenReturn('hello')
+        self.assertEqual('hello', theMock.do_foo())
+
+        clear(theMock)
+
+        self.assertEqual('hello', theMock.do_foo())
 
 
 class TestRaiseOnUnknownObjects:


### PR DESCRIPTION
Adds clear() method to clear all recorded invocations
on mock(s). Useful to be able to check invocations in
particular section of the code without effects of
setup before.

Closes #16