### PR TITLE
Fixes mocking inherited class methods

### DIFF
--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -79,8 +79,8 @@ class Mock(object):
             return None
 
         try:
-            return self.spec.__dict__.get(method_name)
-        except AttributeError:
+            return self.spec.__dict__[method_name]
+        except (AttributeError, KeyError):
             return getattr(self.spec, method_name, None)
 
     def set_method(self, method_name, new_method):

--- a/mockito/utils.py
+++ b/mockito/utils.py
@@ -14,10 +14,7 @@ def contains_strict(seq, element):
 
 
 def newmethod(fn, obj):
-    if PY3:
-        return types.MethodType(fn, obj)
-    else:
-        return types.MethodType(fn, obj, obj.__class__)
+    return types.MethodType(fn, obj)
 
 
 def get_function_host(fn):

--- a/tests/classmethods_test.py
+++ b/tests/classmethods_test.py
@@ -189,14 +189,40 @@ class InheritedClassMethodsTest(TestBase):
         self.assertEqual("woof!", Dog.bark())
         self.assertEqual("stick", Retriever.retrieve("stick"))
 
-    def testUnStubWorksOnClassAndSuperClass(self):
-        when(Retriever).retrieve("stick").thenReturn("ball")
-        when(TrickDog).retrieve("stick").thenReturn("cat")
-        unstub()
-        self.assertEqual("stick", TrickDog.retrieve("stick"))
-
     def testDoubleStubStubWorksAfterUnstub(self):
         when(TrickDog).retrieve("stick").thenReturn("ball")
         when(TrickDog).retrieve("stick").thenReturn("cat")
         unstub()
+        self.assertEqual("stick", TrickDog.retrieve("stick"))
+
+    def testUnStubWorksOnClassAndSuperClass(self):
+        self.assertEqual("stick", Retriever.retrieve("stick"))
+        self.assertEqual("stick", TrickDog.retrieve("stick"))
+
+        when(Retriever).retrieve("stick").thenReturn("ball")
+        self.assertEqual("ball", Retriever.retrieve("stick"))
+        self.assertEqual("ball", TrickDog.retrieve("stick"))
+
+        when(TrickDog).retrieve("stick").thenReturn("cat")
+        self.assertEqual("ball", Retriever.retrieve("stick"))
+        self.assertEqual("cat", TrickDog.retrieve("stick"))
+
+        unstub(TrickDog)
+        self.assertEqual("ball", Retriever.retrieve("stick"))
+        self.assertEqual("ball", TrickDog.retrieve("stick"))
+
+        unstub(Retriever)
+        self.assertEqual("stick", Retriever.retrieve("stick"))
+        self.assertEqual("stick", TrickDog.retrieve("stick"))
+
+    def testReverseOrderWhenUnstubbing(self):
+        when(Retriever).retrieve("stick").thenReturn("ball")
+        when(TrickDog).retrieve("stick").thenReturn("cat")
+
+        unstub(Retriever)
+        self.assertEqual("stick", Retriever.retrieve("stick"))
+        self.assertEqual("cat", TrickDog.retrieve("stick"))
+
+        unstub(TrickDog)
+        self.assertEqual("stick", Retriever.retrieve("stick"))
         self.assertEqual("stick", TrickDog.retrieve("stick"))

--- a/tests/classmethods_test.py
+++ b/tests/classmethods_test.py
@@ -18,9 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from .test_base import TestBase
-from mockito import when, unstub, verify
+from mockito import unstub, verify, when
 from mockito.verification import VerificationError
+
+from .test_base import TestBase
 
 
 class Dog:
@@ -128,16 +129,6 @@ class InheritedClassMethodsTest(TestBase):
         self.assertEqual("woof!", TrickDog.bark())
         self.assertEqual("stick", TrickDog.retrieve("stick"))
 
-    # TODO decent test case please :) without testing irrelevant implementation
-    # details
-    #
-    # TODO This test does not work for inherited @classmethods. but that does
-    # not seem to be because of anything Mockito does.
-    # def testUnstubShouldPreserveMethodType(self):
-    #   when(TrickDog).bark().thenReturn("miau!")
-    #   unstub()
-    #   self.assertTrue(isinstance(TrickDog.__dict__.get("bark"), classmethod))
-
     def testStubs(self):
         self.assertEqual("woof!", TrickDog.bark())
         self.assertEqual("stick", TrickDog.retrieve("stick"))
@@ -147,7 +138,6 @@ class InheritedClassMethodsTest(TestBase):
 
         self.assertEqual("miau!", TrickDog.bark())
         self.assertEqual("ball", TrickDog.retrieve("stick"))
-
 
     def testVerifiesMultipleCallsOnClassmethod(self):
         when(TrickDog).bark().thenReturn("miau!")
@@ -161,7 +151,6 @@ class InheritedClassMethodsTest(TestBase):
 
         verify(TrickDog, times=2).bark()
         verify(TrickDog, times=2).retrieve("stick")
-
 
     def testFailsVerificationOfMultipleCallsOnClassmethod(self):
         when(TrickDog).bark().thenReturn("miau!")
@@ -184,17 +173,6 @@ class InheritedClassMethodsTest(TestBase):
         verify(TrickDog).bark()
         verify(TrickDog).retrieve("stick")
 
-    def testPreservesClassArgumentAfterUnstub(self):
-        self.assertEqual("stick", TrickDog.retrieve("stick"))
-
-        when(TrickDog).retrieve("stick").thenReturn("ball")
-
-        self.assertEqual("ball", TrickDog.retrieve("stick"))
-
-        unstub()
-
-        self.assertEqual("stick", TrickDog.retrieve("stick"))
-
     def testPreservesSuperClassClassMethodWhenStubbed(self):
         self.assertEqual("woof!", Dog.bark())
         self.assertEqual("stick", Retriever.retrieve("stick"))
@@ -210,3 +188,15 @@ class InheritedClassMethodsTest(TestBase):
 
         self.assertEqual("woof!", Dog.bark())
         self.assertEqual("stick", Retriever.retrieve("stick"))
+
+    def testUnStubWorksOnClassAndSuperClass(self):
+        when(Retriever).retrieve("stick").thenReturn("ball")
+        when(TrickDog).retrieve("stick").thenReturn("cat")
+        unstub()
+        self.assertEqual("stick", TrickDog.retrieve("stick"))
+
+    def testDoubleStubStubWorksAfterUnstub(self):
+        when(TrickDog).retrieve("stick").thenReturn("ball")
+        when(TrickDog).retrieve("stick").thenReturn("cat")
+        unstub()
+        self.assertEqual("stick", TrickDog.retrieve("stick"))


### PR DESCRIPTION
Fixes #33 

Mockito loses track of the original_method. Then when the new mocked method is invoked, then invocation is handled as a class method, the first argument is removed, which is what eventually causes the TypeError that shows up in the failing tests. 

This change finds the original method if a classmethod is brought in through inheritance.  It also addresses a test failure against Python 2.7 that showed up after fixing the initial problem.