### PR TITLE
Change Implementation for ArgumentCaptor to capture all invocations

### DIFF
--- a/mockito/verification.py
+++ b/mockito/verification.py
@@ -22,6 +22,7 @@ import operator
 
 __all__ = ['never', 'VerificationError']
 
+
 class VerificationError(AssertionError):
     '''Indicates error during verification of invocations.
 

--- a/tests/matchers_test.py
+++ b/tests/matchers_test.py
@@ -17,7 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
+from mockito.matchers import MatcherError
 from .test_base import TestBase
 from mockito import mock, verify
 from mockito.matchers import and_, or_, not_, eq, neq, lt, lte, gt, gte, \
@@ -211,30 +211,38 @@ class ArgumentCaptorTest(TestBase):
     def testShouldSatisfyIfInnerMatcherIsSatisfied(self):
         c = captor(contains("foo"))
         self.assertTrue(c.matches("foobar"))
+        self.assertListEqual(["foobar", ], c.all_values)
 
     def testShouldNotSatisfyIfInnerMatcherIsNotSatisfied(self):
         c = captor(contains("foo"))
         self.assertFalse(c.matches("barbam"))
+        self.assertListEqual([], c.all_values)
 
     def testShouldReturnNoneValueByDefault(self):
         c = captor(contains("foo"))
-        self.assertEqual(None, c.value)
+        self.assertListEqual([], c.all_values)
+        with self.assertRaises(MatcherError):
+            _ = c.value
 
     def testShouldReturnNoneValueIfDidntMatch(self):
         c = captor(contains("foo"))
         c.matches("bar")
-        self.assertEqual(None, c.value)
+        self.assertListEqual([], c.all_values)
+        with self.assertRaises(MatcherError):
+            _ = c.value
 
     def testShouldReturnLastMatchedValue(self):
         c = captor(contains("foo"))
         c.matches("foobar")
         c.matches("foobam")
         c.matches("bambaz")
+        self.assertListEqual(["foobar", "foobam"], c.all_values)
         self.assertEqual("foobam", c.value)
 
     def testShouldDefaultMatcherToAny(self):
         c = captor()
         c.matches("foo")
         c.matches(123)
+        self.assertListEqual(["foo", 123], c.all_values)
         self.assertEqual(123, c.value)
 


### PR DESCRIPTION
Fixes #41 

### Description

Change impl of ArgumentCaptor to capture all the invocations in an attribute called `all_values`. 

### Backward Compatibility

Not maintained with this change

### Whats backward incompatible

1. Previously `value` used to return `None` when the argument was not captured. After this change, the code will throw a `MatcherError`(RuntimeError)

### New Attributes

1. `all_values`: List of all the invocations captured by the `ArgumentCaptor`. If there are no invocations, the list is empty.



