### PR TITLE
Fix: Only record captured arguments in execution phase

### DIFF
--- a/mockito/matchers.py
+++ b/mockito/matchers.py
@@ -59,6 +59,7 @@ The one usage you should not care about is a loose signature when using
 
 """
 
+from abc import ABC, abstractmethod
 import re
 builtin_any = any
 
@@ -116,6 +117,11 @@ class MatcherError(RuntimeError):
 
 class Matcher:
     def matches(self, arg):
+        pass
+
+class Capturing(ABC):
+    @abstractmethod
+    def capture_value(self, value):
         pass
 
 
@@ -249,7 +255,7 @@ class Matches(Matcher):
             return "<Matches: %s>" % self.regex.pattern
 
 
-class ArgumentCaptor(Matcher):
+class ArgumentCaptor(Matcher, Capturing):
     def __init__(self, matcher=None):
         self.matcher = matcher or Any()
         self.all_values = []
@@ -258,7 +264,6 @@ class ArgumentCaptor(Matcher):
         result = self.matcher.matches(arg)
         if not result:
             return
-        self.all_values.append(arg)
         return True
 
     @property
@@ -266,6 +271,9 @@ class ArgumentCaptor(Matcher):
         if not self.all_values:
             raise MatcherError("No argument value was captured!")
         return self.all_values[-1]
+
+    def capture_value(self, value):
+        self.all_values.append(value)
 
     def __repr__(self):
         return "<ArgumentCaptor: matcher=%s values=%s>" % (

--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -35,7 +35,7 @@ __tracebackhide__ = operator.methodcaller(
 
 MYPY = False
 if MYPY:
-    from typing import Deque, Union
+    from typing import Deque, List, Union
     RealInvocation = Union[
         invocation.RememberedInvocation,
         invocation.RememberedProxyInvocation
@@ -61,7 +61,7 @@ class Mock(object):
         self.strict = strict
         self.spec = spec
 
-        self.invocations = deque()  # type: Deque[RealInvocation]
+        self.invocations = []  # type: List[RealInvocation]
         self.stubbed_invocations = deque()  \
             # type: Deque[invocation.StubbedInvocation]
 
@@ -69,13 +69,13 @@ class Mock(object):
         self._signatures_store = {}
 
     def remember(self, invocation):
-        self.invocations.appendleft(invocation)
+        self.invocations.append(invocation)
 
     def finish_stubbing(self, stubbed_invocation):
         self.stubbed_invocations.appendleft(stubbed_invocation)
 
     def clear_invocations(self):
-        self.invocations = deque()
+        self.invocations = []
 
     # STUBBING
 

--- a/mockito/verification.py
+++ b/mockito/verification.py
@@ -105,7 +105,7 @@ Instead got:
                 % (
                     invocation,
                     "\n    ".join(
-                        str(invoc) for invoc in reversed(invocations)
+                        str(invoc) for invoc in invocations
                     )
                 )
             )
@@ -137,7 +137,7 @@ class InOrder(object):
         self.original_verification = original_verification
 
     def verify(self, wanted_invocation, count):
-        for invocation in reversed(wanted_invocation.mock.invocations):
+        for invocation in wanted_invocation.mock.invocations:
             if not invocation.verified_inorder:
                 if not wanted_invocation.matches(invocation):
                     raise VerificationError(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+xfail_strict=true

--- a/tests/matchers_test.py
+++ b/tests/matchers_test.py
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 from mockito.matchers import MatcherError
 from .test_base import TestBase
-from mockito import mock, verify
+from mockito import mock, verify, when
 from mockito.matchers import and_, or_, not_, eq, neq, lt, lte, gt, gte, \
     any_, arg_that, contains, matches, captor, ANY, ARGS, KWARGS
 import re
@@ -208,41 +208,72 @@ class MatchesMatcherTest(TestBase):
 
 
 class ArgumentCaptorTest(TestBase):
-    def testShouldSatisfyIfInnerMatcherIsSatisfied(self):
-        c = captor(contains("foo"))
-        self.assertTrue(c.matches("foobar"))
-        self.assertListEqual(["foobar", ], c.all_values)
+    def test_matches_anything_by_default(self):
+        assert captor().matches(12)
+        assert captor().matches("anything")
+        assert captor().matches(int)
 
-    def testShouldNotSatisfyIfInnerMatcherIsNotSatisfied(self):
-        c = captor(contains("foo"))
-        self.assertFalse(c.matches("barbam"))
-        self.assertListEqual([], c.all_values)
+    def test_matches_is_constrained_by_inner_matcher(self):
+        assert captor(any_(int)).matches(12)
+        assert not captor(any_(int)).matches("12")
 
-    def testShouldReturnNoneValueByDefault(self):
-        c = captor(contains("foo"))
-        self.assertListEqual([], c.all_values)
-        with self.assertRaises(MatcherError):
-            _ = c.value
-
-    def testShouldReturnNoneValueIfDidntMatch(self):
-        c = captor(contains("foo"))
-        c.matches("bar")
-        self.assertListEqual([], c.all_values)
-        with self.assertRaises(MatcherError):
-            _ = c.value
-
-    def testShouldReturnLastMatchedValue(self):
-        c = captor(contains("foo"))
-        c.matches("foobar")
-        c.matches("foobam")
-        c.matches("bambaz")
-        self.assertListEqual(["foobar", "foobam"], c.all_values)
-        self.assertEqual("foobam", c.value)
-
-    def testShouldDefaultMatcherToAny(self):
+    def test_all_values_initially_is_empty(self):
         c = captor()
-        c.matches("foo")
-        c.matches(123)
-        self.assertListEqual(["foo", 123], c.all_values)
-        self.assertEqual(123, c.value)
+        assert c.all_values == []
+
+    def test_captures_all_values(self):
+        m = mock()
+        c = captor()
+
+        when(m).do(c)
+        m.do("any")
+        m.do("thing")
+
+        assert c.all_values == ["any", "thing"]
+
+    def test_captures_only_matching_values(self):
+        m = mock()
+        c = captor(any_(int))
+
+        when(m).do(c)
+        m.do("any")
+        m.do("thing")
+        m.do(21)
+
+        assert c.all_values == [21]
+
+    def test_captures_all_values_while_verifying(self):
+        m = mock()
+        c = captor()
+
+        m.do("any")
+        m.do("thing")
+        verify(m, times=2).do(c)
+
+        assert c.all_values == ["any", "thing"]
+
+    def test_remember_last_value(self):
+        m = mock()
+        c = captor()
+
+        when(m).do(c)
+        m.do("any")
+        m.do("thing")
+
+        assert c.value == "thing"
+
+    def test_remember_last_value_while_verifying(self):
+        m = mock()
+        c = captor()
+
+        m.do("any")
+        m.do("thing")
+        verify(m, times=2).do(c)
+
+        assert c.value == "thing"
+
+    def test_accessing_value_throws_if_nothing_captured_yet(self):
+        c = captor()
+        with self.assertRaises(MatcherError):
+            _ = c.value
 

--- a/tests/matchers_test.py
+++ b/tests/matchers_test.py
@@ -277,3 +277,22 @@ class ArgumentCaptorTest(TestBase):
         with self.assertRaises(MatcherError):
             _ = c.value
 
+    def test_expose_issue_49_using_when(self):
+        m = mock()
+        c = captor()
+
+        when(m).do(c, 10)
+        when(m).do(c, 11)
+        m.do("anything", 10)
+
+        assert c.all_values == ["anything"]
+
+    def test_expose_issue_49_using_verify(self):
+        m = mock()
+        c = captor()
+
+        m.do("anything", 10)
+        verify(m).do(c, 10)
+        verify(m, times=0).do(c, 11)
+
+        assert c.all_values == ["anything"]


### PR DESCRIPTION
Fixes #49 

Our `captor` recorded its use as a by product of successfully using
(actually: asking) `matches`.  This leads to wrong behavior as soon
as the captor matches but the call signature as a whole still fails.

For example consider `when(foo).bar(captor(), 11)`.  Here the "any"
captor always matches even when the second argument, the literal "11",
fails.

Make the side-effect explicit by implementing a new `capture_arguments`
which is called if the whole call signature matches.