### PR TITLE
Fix: support `mock(spec=SomeClass)` usage

### DIFF
--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -265,10 +265,9 @@ def mock(config_or_spec=None, spec=None, strict=OMITTED):
     """
 
     if type(config_or_spec) is dict:
-        config = config_or_spec
+        config, spec = config_or_spec, spec
     else:
-        config = {}
-        spec = config_or_spec
+        config, spec = {}, spec or config_or_spec
 
     if strict is OMITTED:
         strict = False if spec is None else True

--- a/tests/speccing_test.py
+++ b/tests/speccing_test.py
@@ -102,6 +102,21 @@ class TestSpeccing:
 
         assert isinstance(action, Action)
 
+    def testShouldPassIsInstanceChecks_2(self):
+        action = mock(spec=Action)
+
+        assert isinstance(action, Action)
+
+    def testShouldPassIsInstanceChecks_3(self):
+        action = mock({}, Action)
+
+        assert isinstance(action, Action)
+
+    def testShouldPassIsInstanceChecks_4(self):
+        action = mock({}, spec=Action)
+
+        assert isinstance(action, Action)
+
     def testHasANiceName(self):
         action = mock(Action)
 


### PR DESCRIPTION
Support specifying the spec by using the keyword `spec`.

Although in the documentation it is always spelt `mock(SomeClass)`
it is confusing to not allow the keyword invocation
`mock(spec=SomeClass)` here to mean the same thing.

It can be considered a bug because using the keyword `spec=X` just
ignored the argument and created a non-strict, non-specced (dumb) mock;
basically a plain `mock()`.

This came up here: https://stackoverflow.com/questions/72498759/python-mockito-how-do-i-set-up-async-mocks?noredirect=1#comment128270001_72498759