### PR TITLE
Unstub singleton methods exposed as module functions

### DIFF
--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -180,8 +180,11 @@ class Mock(object):
         # the one on its class, so we delete as well.
         if (
             not original_method
-            or not inspect.isclass(self.mocked_obj)
-            and inspect.ismethod(original_method)
+            or (
+                inspect.ismethod(original_method)
+                and not inspect.isclass(self.mocked_obj)
+                and not inspect.ismodule(self.mocked_obj)
+            )
         ):
             delattr(self.mocked_obj, method_name)
         else:

--- a/tests/modulefunctions_test.py
+++ b/tests/modulefunctions_test.py
@@ -98,3 +98,10 @@ class ModuleFunctionsTest(TestBase):
         from . import module
         when(module).Foo().thenReturn('mocked')
         assert module.Foo() == 'mocked'
+
+    def testUnstubFunctionOnModuleWhichIsActuallyAMethod_issue_53(self):
+        import random
+        when(random).randint(...).thenReturn("mocked")
+        assert random.randint(1, 10) == "mocked"
+        unstub(random)
+        assert random.randint(1, 10) != "mocked"


### PR DESCRIPTION
Fixes #53

The library module `random` exposes as its main API "functions" on the
module level which are actually bound methods detached from a singleton
`Random()` instance.

If a user mocked these, for example `random.randint`, these were not
restored correctly on `unstub` but deleted.

We hotfix here by adding another check (`ismodule`).