### PR TITLE
Implementation of thenCallOriginalImplementation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,21 @@
 MOCKITO CHANGE LOG
 ==================
 
+Release 1.4.0
+-------------
+
+- @avandierast implemented `thenCallOriginalImplementation`.  See #60
+
+::
+
+    # Let `os.path.exists` use the real filesystem (often needed when
+    # the testing framework needs itself a working `os.path.exists`
+    # implementation) *but* fake a `.flake8` file.
+    when(os.path).exists(...).thenCallOriginalImplementation()
+    when(os.path).exists('.flake8').thenReturn(True)
+
+
+
 Release 1.3.5 (August 18, 2022)
 -------------------------------
 

--- a/docs/walk-through.rst
+++ b/docs/walk-through.rst
@@ -19,6 +19,7 @@ There are of course reasons when you don't want to overspecify specific tests. Y
 
     # now, obviously, you get the same answer, regardless of the arguments
     os.path.exists('FooBar')  # => True
+    os.path.exists('BarFoo')  # => True
 
 You can combine both stubs. E.g. nothing exists, except one file::
 
@@ -30,6 +31,21 @@ And because it's a similar pattern, we can introduce :func:`spy2` here. Spies ca
     from mockito import spy2
     spy2(os.path.exists)
     when(os.path).exists('.flake8').thenReturn(False)
+
+Another way to write the same thing is::
+
+    when(os.path).exists(...).thenCallOriginalImplementation()
+    when(os.path).exists('.flake8').thenReturn(False)
+
+And actually `spy2` uses `thenCallOriginalImplementation` under the hood.  Why spying at all: either you want the implementation *almost* intact as above or you
+need the implementation to stay intact but want to `verify` its usage.  E.g.::
+
+    spy2(os.path.exists)
+    # now do some stuff
+    do_stuff()
+    # then verify the we asked for the cache exactly once
+    verify(os.path, times=1).exists("cache/.foo")
+
 
 When patching, you **MUST** **not** forget to :func:`unstub` of course! You can do this explicitly
 

--- a/mockito/invocation.py
+++ b/mockito/invocation.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 import functools
+import inspect
 import operator
 from collections import deque
 
@@ -32,6 +33,9 @@ if MYPY:
 
 
 class InvocationError(AttributeError):
+    pass
+
+class AnswerError(AttributeError):
     pass
 
 
@@ -84,12 +88,16 @@ class RememberedInvocation(Invocation):
         signature.match_signature(sig, args, kwargs)
 
     def __call__(self, *params, **named_params):
+        if self.mock.eat_self(self.method_name):
+            params_without_first_arg = params[1:]
+        else:
+            params_without_first_arg = params
         if self.strict:
             self.ensure_mocked_object_has_method(self.method_name)
             self.ensure_signature_matches(
-                self.method_name, params, named_params)
+                self.method_name, params_without_first_arg, named_params)
 
-        self._remember_params(params, named_params)
+        self._remember_params(params_without_first_arg, named_params)
         self.mock.remember(self)
 
         for matching_invocation in self.mock.stubbed_invocations:
@@ -408,23 +416,60 @@ def raise_(exception, *a, **kw):
     raise exception
 
 
+def discard_self(function):
+    def function_without_self(*args, **kwargs):
+        args = args[1:]
+        return function(*args, **kwargs)
+
+    return function_without_self
+
+
 class AnswerSelector(object):
     def __init__(self, invocation):
         self.invocation = invocation
+        self.discard_first_arg = \
+            invocation.mock.eat_self(invocation.method_name)
 
     def thenReturn(self, *return_values):
         for return_value in return_values:
-            self.__then(functools.partial(return_, return_value))
+            answer = functools.partial(return_, return_value)
+            self.__then(answer)
         return self
 
     def thenRaise(self, *exceptions):
         for exception in exceptions:
-            self.__then(functools.partial(raise_, exception))
+            answer = functools.partial(raise_, exception)
+            self.__then(answer)
         return self
 
     def thenAnswer(self, *callables):
         for callable in callables:
-            self.__then(callable)
+            answer = callable
+            if self.discard_first_arg:
+                answer = discard_self(answer)
+            self.__then(answer)
+        return self
+
+    def thenCallOriginalImplementation(self):
+        answer = self.invocation.mock.get_original_method(
+            self.invocation.method_name
+        )
+        if not answer:
+            raise AnswerError(
+                "'%s' has no original implementation for '%s'." %
+                (self.invocation.mock.mocked_obj, self.invocation.method_name)
+            )
+        if (
+            # A classmethod is not callable
+            # and a staticmethod is not callable in old version of python,
+            # so we get the underlying function.
+            isinstance(answer, classmethod) or isinstance(answer, staticmethod)
+            # If the method is bound, we unbind it.
+            or inspect.ismethod(answer)
+        ):
+            answer = answer.__func__
+
+        self.__then(answer)
         return self
 
     def __then(self, answer):

--- a/mockito/invocation.py
+++ b/mockito/invocation.py
@@ -18,15 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from . import matchers
+import functools
 import operator
-from . import signature
+from collections import deque
+
+from . import matchers, signature
 from . import verification as verificationModule
 from .utils import contains_strict
-
-from collections import deque
-import functools
-
 
 MYPY = False
 if MYPY:

--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -65,7 +65,8 @@ class Mock(object):
         self.stubbed_invocations = deque()  \
             # type: Deque[invocation.StubbedInvocation]
 
-        self.original_methods = {}
+        self._original_methods = {}
+        self._methods_to_unstub = {}
         self._signatures_store = {}
 
     def remember(self, invocation):
@@ -77,9 +78,12 @@ class Mock(object):
     def clear_invocations(self):
         self.invocations = []
 
+    def get_original_method(self, method_name):
+        return self._original_methods.get(method_name, None)
+
     # STUBBING
 
-    def get_original_method(self, method_name):
+    def _get_original_method_before_stub(self, method_name):
         """
         Looks up the original method on the `spec` object and returns it
         together with an indication of whether the method is found
@@ -144,17 +148,20 @@ class Mock(object):
 
     def stub(self, method_name):
         try:
-            self.original_methods[method_name]
+            self._methods_to_unstub[method_name]
         except KeyError:
-            original_method, was_in_spec = self.get_original_method(
-                method_name)
+            (
+                original_method,
+                was_in_spec
+            ) = self._get_original_method_before_stub(method_name)
             if was_in_spec:
                 # This indicates the original method was found directly on
                 # the spec object and should therefore be restored by unstub
-                self.original_methods[method_name] = original_method
+                self._methods_to_unstub[method_name] = original_method
             else:
-                self.original_methods[method_name] = None
+                self._methods_to_unstub[method_name] = None
 
+            self._original_methods[method_name] = original_method
             self.replace_method(method_name, original_method)
 
     def forget_stubbed_invocation(self, invocation):
@@ -170,7 +177,9 @@ class Mock(object):
             inv.method_name == invocation.method_name
             for inv in self.stubbed_invocations
         ):
-            original_method = self.original_methods.pop(invocation.method_name)
+            original_method = self._methods_to_unstub.pop(
+                invocation.method_name
+            )
             self.restore_method(invocation.method_name, original_method)
 
     def restore_method(self, method_name, original_method):
@@ -182,8 +191,8 @@ class Mock(object):
             delattr(self.mocked_obj, method_name)
 
     def unstub(self):
-        while self.original_methods:
-            method_name, original_method = self.original_methods.popitem()
+        while self._methods_to_unstub:
+            method_name, original_method = self._methods_to_unstub.popitem()
             self.restore_method(method_name, original_method)
         self.stubbed_invocations = deque()
         self.invocations = []

--- a/mockito/mockito.py
+++ b/mockito/mockito.py
@@ -238,7 +238,8 @@ def when2(fn, *args, **kwargs):
     more documentation.
 
     Returns `AnswerSelector` interface which exposes `thenReturn`,
-    `thenRaise`, and `thenAnswer` as usual. Always `strict`.
+    `thenRaise`, `thenAnswer`, and `thenCallOriginalImplementation` as usual.
+    Always `strict`.
 
     Usage::
 

--- a/mockito/spying.py
+++ b/mockito/spying.py
@@ -25,7 +25,6 @@ import inspect
 from .mockito import when2
 from .invocation import RememberedProxyInvocation
 from .mocking import Mock, _Dummy, mock_registry
-from .utils import get_obj
 
 __all__ = ['spy']
 
@@ -96,10 +95,4 @@ def spy2(fn):  # type: (...) -> None
 
 
     """
-    if isinstance(fn, str):
-        answer = get_obj(fn)
-    else:
-        answer = fn
-
-    when2(fn, Ellipsis).thenAnswer(answer)
-
+    when2(fn, Ellipsis).thenCallOriginalImplementation()

--- a/tests/call_original_implem_test.py
+++ b/tests/call_original_implem_test.py
@@ -1,0 +1,82 @@
+
+import sys
+
+import pytest
+from mockito import mock, when
+from mockito.invocation import AnswerError
+
+from . import module
+from .test_base import TestBase
+
+
+class Dog:
+    def __init__(self, huge=False):
+        self.huge = huge
+
+    def bark(self):
+        if self.huge:
+            return "woof"
+        else:
+            return "waf ! waf ! waf ! waf ! waf ! waf !"
+
+    @classmethod
+    def class_bark(cls):
+        return cls.__name__ + " woof"
+
+    @staticmethod
+    def static_bark(arg):
+        return str(arg) + " woof"
+
+
+class CallOriginalImplementationTest(TestBase):
+
+    def testClassMethod(self):
+        when(Dog).class_bark().thenCallOriginalImplementation()
+
+        self.assertEqual("Dog woof", Dog.class_bark())
+
+    def testStaticMethod(self):
+        when(Dog).static_bark("wif").thenCallOriginalImplementation()
+        self.assertEqual("wif woof", Dog.static_bark("wif"))
+
+    def testStaticMethodOnInstance(self):
+        dog = Dog()
+        when(Dog).static_bark("wif").thenCallOriginalImplementation()
+        self.assertEqual("wif woof", dog.static_bark("wif"))
+
+    def testMethod(self):
+        when(Dog).bark().thenCallOriginalImplementation()
+
+        assert Dog(huge=True).bark() == "woof"
+
+    def testMethodOnInstance(self):
+        dog = Dog(huge=True)
+        when(dog).bark().thenCallOriginalImplementation()
+
+        assert dog.bark() == "woof"
+
+    def testFunction(self):
+        when(module).one_arg(Ellipsis).thenCallOriginalImplementation()
+        assert module.one_arg("woof") == "woof"
+
+    def testChain(self):
+        when(module).one_arg(Ellipsis) \
+                    .thenReturn("wif") \
+                    .thenCallOriginalImplementation()
+        assert module.one_arg("woof") == "wif"
+        assert module.one_arg("woof") == "woof"
+
+    def testNoOriginal(self):
+        dog = mock()
+        answer_selector = when(dog).bark()
+        with pytest.raises(AnswerError) as exc:
+            answer_selector.thenCallOriginalImplementation()
+
+        if sys.version_info >= (3, 0):
+            class_str_value = "mockito.mocking.mock.<locals>.Dummy"
+        else:
+            class_str_value = "mockito.mocking.Dummy"
+        assert str(exc.value) == (
+            "'<class '%s'>' "
+            "has no original implementation for 'bark'."
+        ) % class_str_value

--- a/tests/call_original_implem_test.py
+++ b/tests/call_original_implem_test.py
@@ -66,7 +66,7 @@ class CallOriginalImplementationTest(TestBase):
         assert module.one_arg("woof") == "wif"
         assert module.one_arg("woof") == "woof"
 
-    def testNoOriginal(self):
+    def testDumbMockHasNoOriginalImplementations(self):
         dog = mock()
         answer_selector = when(dog).bark()
         with pytest.raises(AnswerError) as exc:

--- a/tests/call_original_implem_test.py
+++ b/tests/call_original_implem_test.py
@@ -62,9 +62,11 @@ class CallOriginalImplementationTest(TestBase):
     def testChain(self):
         when(module).one_arg(Ellipsis) \
                     .thenReturn("wif") \
-                    .thenCallOriginalImplementation()
+                    .thenCallOriginalImplementation() \
+                    .thenReturn("waf")
         assert module.one_arg("woof") == "wif"
         assert module.one_arg("woof") == "woof"
+        assert module.one_arg("woof") == "waf"
 
     def testDumbMockHasNoOriginalImplementations(self):
         dog = mock()

--- a/tests/call_original_implem_test.py
+++ b/tests/call_original_implem_test.py
@@ -80,3 +80,8 @@ class CallOriginalImplementationTest(TestBase):
             "'<class '%s'>' "
             "has no original implementation for 'bark'."
         ) % class_str_value
+
+    def testSpeccedMockHasOriginalImplementations(self):
+        dog = mock({"huge": True}, spec=Dog)
+        when(dog).bark().thenCallOriginalImplementation()
+        assert dog.bark() == "woof"

--- a/tests/ellipsis_test.py
+++ b/tests/ellipsis_test.py
@@ -1,9 +1,8 @@
 
-import pytest
-
 from collections import namedtuple
 
-from mockito import when, args, kwargs, invocation, mock
+import pytest
+from mockito import args, invocation, kwargs, mock, when
 
 
 class Dog(object):

--- a/tests/modulefunctions_test.py
+++ b/tests/modulefunctions_test.py
@@ -106,3 +106,8 @@ class ModuleFunctionsTest(TestBase):
         assert random.randint(1, 10) == "mocked"
         unstub(random)
         assert random.randint(1, 10) != "mocked"
+
+    def testAddFakeMethodInNotStrictMode(self):
+        when(os.path, strict=False).new_exists("test").thenReturn(True)
+
+        self.assertEqual(True, os.path.new_exists("test"))

--- a/tests/modulefunctions_test.py
+++ b/tests/modulefunctions_test.py
@@ -20,10 +20,11 @@
 
 import os
 
-from .test_base import TestBase
-from mockito import when, unstub, verify, any
+from mockito import any, unstub, verify, when
 from mockito.invocation import InvocationError
 from mockito.verification import VerificationError
+
+from .test_base import TestBase
 
 
 class ModuleFunctionsTest(TestBase):

--- a/tests/spying_test.py
+++ b/tests/spying_test.py
@@ -154,3 +154,7 @@ class TestSpy2:
         assert dummy.return_args('box') == 'foo'
         assert dummy.return_args('fox') == 'fix'
 
+    def testSpyOnClass(self):
+        spy2(Dummy.foo)
+        assert Dummy().foo() == 'foo'
+

--- a/tests/staticmethods_test.py
+++ b/tests/staticmethods_test.py
@@ -18,9 +18,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from .test_base import TestBase
-from mockito import when, verify, unstub, any
+from mockito import any, unstub, verify, when
 from mockito.verification import VerificationError
+
+from .test_base import TestBase
+
 
 class Dog:
     @staticmethod

--- a/tests/staticmethods_test.py
+++ b/tests/staticmethods_test.py
@@ -78,6 +78,14 @@ class StaticMethodsTest(TestBase):
 
         self.assertEqual("miau", Dog.barkHardly(1, 2))
 
+    def testStubsWithArgsOnInstance(self):
+        dog = Dog()
+        self.assertEqual("woof woof", dog.barkHardly(1, 2))
+
+        when(Dog).barkHardly(1, 2).thenReturn("miau")
+
+        self.assertEqual("miau", dog.barkHardly(1, 2))
+
     def testStubsButDoesNotMachArguments(self):
         self.assertEqual("woof woof", Dog.barkHardly(1, "anything"))
 

--- a/tests/stubbing_test.py
+++ b/tests/stubbing_test.py
@@ -19,9 +19,9 @@
 # THE SOFTWARE.
 
 import pytest
+from mockito import any, mock, times, verify, when
 
 from .test_base import TestBase
-from mockito import mock, when, verify, times, any
 
 
 class TestEmptyMocks:

--- a/tests/stubbing_test.py
+++ b/tests/stubbing_test.py
@@ -375,7 +375,7 @@ class StubbingTest(TestBase):
         self.assertEqual(m.with_key_words(testing="Very Funky"),
                          "Very Funky Stuff")
 
-    def testSubsWithThenAnswerAndMixedArgs(self):
+    def testStubsWithThenAnswerAndMixedArgs(self):
         repo = mock()
 
         def method_one(value, active_only=False):


### PR DESCRIPTION
The implementation of thenCallOriginalImplementation required a refactor of the way self is discarded.
Now, self is kept in the params and discarded only when we don't need it.

Linked to #46 #48

I've also corrected some tests where the objects was used instead of the mock.