### PR TITLE
Simplify restore_method

### DIFF
--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -176,19 +176,10 @@ class Mock(object):
     def restore_method(self, method_name, original_method):
         # If original_method is None, we *added* it to mocked_obj, so we
         # must delete it here.
-        # If we mocked an instance, our mocked function will actually hide
-        # the one on its class, so we delete as well.
-        if (
-            not original_method
-            or (
-                inspect.ismethod(original_method)
-                and not inspect.isclass(self.mocked_obj)
-                and not inspect.ismodule(self.mocked_obj)
-            )
-        ):
-            delattr(self.mocked_obj, method_name)
-        else:
+        if original_method:
             self.set_method(method_name, original_method)
+        else:
+            delattr(self.mocked_obj, method_name)
 
     def unstub(self):
         while self.original_methods:

--- a/tests/instancemethods_test.py
+++ b/tests/instancemethods_test.py
@@ -73,6 +73,14 @@ class InstanceMethodsTest(TestBase):
         unstub()
         assert rex.waggle() == 'Wuff!'
 
+    def testPartialUnstubShowsTheMockedClass(self):
+        when(Dog).waggle().thenReturn('Nope!')
+
+        rex = Dog()
+        when(rex).waggle().thenReturn('Sure!')
+        unstub(rex)
+
+        assert rex.waggle() == 'Nope!'
 
     def testStubAnInstanceMethod(self):
         when(Dog).waggle().thenReturn('Boing!')


### PR DESCRIPTION
Drastically reducing the conditionals does *not* break any test.
Probably introducing the better `was_in_spec` test in
`get_original_method` is enough and can be used here safely.

Comparing this to Python's `mock` library from the standard lib suggest
this to be true as well.