### PR TITLE
Clear internal state when unstubbing

### DIFF
--- a/mockito/mocking.py
+++ b/mockito/mocking.py
@@ -185,6 +185,8 @@ class Mock(object):
         while self.original_methods:
             method_name, original_method = self.original_methods.popitem()
             self.restore_method(method_name, original_method)
+        self.stubbed_invocations = deque()
+        self.invocations = []
 
     # SPECCING
 

--- a/tests/unstub_test.py
+++ b/tests/unstub_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mockito import when, unstub, verify, ArgumentError
+from mockito import mock, when, unstub, verify, ArgumentError
 
 
 class Dog(object):
@@ -30,6 +30,13 @@ class TestUntub:
         unstub(mox)
 
         assert mox.waggle() == 'Unsure'
+
+    def testUnconfigureMock(self):
+        m = mock()
+        when(m).foo().thenReturn(42)
+        assert m.foo() == 42
+        unstub(m)
+        assert m.foo() is None
 
 class TestAutomaticUnstubbing:
 
@@ -128,3 +135,4 @@ class TestAutomaticUnstubbing:
                 assert rex.waggle() == 'Sure'
 
                 verify(Dog).waggle()
+


### PR DESCRIPTION
See #56

For plain `mock`s unstubbing did not reset their state.

It works for patched objects because we first restore the old method
away the mock object ("unregister"), hence there is no way to further
access old recorded invocations.

A mock is usually assigned to local variable thus still accessible.
Although the registry doesn't point to it anymore, the mock itself
(actually a `Dummy` instance) still points to the underlying recording
Mock.