### PR TITLE
Make Github actions pass

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.1-dev
+current_version = 1.5.0-dev
 commit = True
 message = Bump version to {new_version}
 tag = True

--- a/.github/workflows/test-lint-go.yml
+++ b/.github/workflows/test-lint-go.yml
@@ -18,7 +18,7 @@ jobs:
           - '3.12'
     name: Run tests on Python ${{ matrix.python-version }} (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint with flake8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Spellcheck with codespell
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check with mypy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to pypi
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test-lint-go.yml
+++ b/.github/workflows/test-lint-go.yml
@@ -15,6 +15,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
     name: Run tests on Python ${{ matrix.python-version }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-lint-go.yml
+++ b/.github/workflows/test-lint-go.yml
@@ -13,7 +13,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-          - '3.11-dev'
+          - '3.11'
     name: Run tests on Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-lint-go.yml
+++ b/.github/workflows/test-lint-go.yml
@@ -9,9 +9,6 @@ jobs:
       fail-fast: false
       matrix:
           python-version:
-          - '2.7'
-          - '3.5'
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/.github/workflows/test-lint-go.yml
+++ b/.github/workflows/test-lint-go.yml
@@ -4,17 +4,18 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
           python-version:
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
-    name: Run tests on Python ${{ matrix.python-version }}
+    name: Run tests on Python ${{ matrix.python-version }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/.github/workflows/test-lint-go.yml
+++ b/.github/workflows/test-lint-go.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.github/workflows/test-lint-go.yml
+++ b/.github/workflows/test-lint-go.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install 'flake8<6.0.0'
       - name: Run flake8
         run: flake8 .
 

--- a/mockito/__init__.py
+++ b/mockito/__init__.py
@@ -44,7 +44,7 @@ from .matchers import *  # noqa: F401 F403
 from .matchers import any, contains, times
 from .verification import never
 
-__version__ = '1.4.1-dev'
+__version__ = '1.5.0-dev'
 
 __all__ = [
     'mock',

--- a/mockito/utils.py
+++ b/mockito/utils.py
@@ -7,6 +7,8 @@ import re
 
 
 PY3 = sys.version_info >= (3,)
+NEEDS_OS_PATH_HACK = (
+    sys.platform == "win32" and (3, 12) <= sys.version_info < (3, 13))
 
 
 def contains_strict(seq, element):
@@ -34,6 +36,12 @@ def get_function_host(fn):
     try:
         name = fn.__name__
         obj = fn.__self__
+        if (
+            NEEDS_OS_PATH_HACK
+            and obj.__name__ == "nt"
+            and name.startswith('_path_')
+        ):
+            obj = None
     except AttributeError:
         pass
 


### PR DESCRIPTION
- Remove unsupported python versions (2.7, 3.5, 3.6) from the tests matrix
- Pin flake8 version<6 as we use type comments
- Test on v3.12