### PR TITLE
Update `expect` to support dotted paths

### DIFF
--- a/mockito/mockito.py
+++ b/mockito/mockito.py
@@ -300,6 +300,10 @@ def expect(obj, strict=None,
         # maybe if you need to ensure that `dog.bark()` was called at all
         verifyNoUnwantedInteractions()
 
+        # If the lower bound of between is set to 0, expect behaves similar
+        to lenient from Java mockito. I.e. verifyStubbedInvocationsAreUsed
+        passes even if stubbed function is not called in test.
+
     .. note:: You must :func:`unstub` after stubbing, or use `with`
         statement.
 

--- a/mockito/mockito.py
+++ b/mockito/mockito.py
@@ -300,18 +300,6 @@ def expect(obj, strict=None,
         # maybe if you need to ensure that `dog.bark()` was called at all
         verifyNoUnwantedInteractions()
 
-    If the lower bound of ``between`` is set to 0, :func:`expect`
-    behaves similar to a lenient stub from Java Mockito.
-    I.e. :func:`verifyStubbedInvocationsAreUsed` passes even if
-    stubbed function is not called in test::
-
-        # We set our expectation
-        expect('os.path', between=(0, 3)).exists("/path").thenReturn(True)
-
-        # No call to os.path.exists happens here
-
-        verifyStubbedInvocationsAreUsed() # This passes
-
     .. note:: You must :func:`unstub` after stubbing, or use `with`
         statement.
 

--- a/mockito/mockito.py
+++ b/mockito/mockito.py
@@ -301,7 +301,7 @@ def expect(obj, strict=None,
         verifyNoUnwantedInteractions()
 
     If the lower bound of ``between`` is set to 0, :func:`expect`
-    behaves similar to lenient from Java Mockito.
+    behaves similar to a lenient stub from Java Mockito.
     I.e. :func:`verifyStubbedInvocationsAreUsed` passes even if
     stubbed function is not called in test::
 

--- a/mockito/mockito.py
+++ b/mockito/mockito.py
@@ -306,6 +306,10 @@ def expect(obj, strict=None,
     See :func:`when`, :func:`when2`, :func:`verifyNoUnwantedInteractions`
 
     """
+
+    if isinstance(obj, str):
+        obj = get_obj(obj)
+
     if strict is None:
         strict = True
     theMock = _get_mock(obj, strict=strict)

--- a/mockito/mockito.py
+++ b/mockito/mockito.py
@@ -300,9 +300,17 @@ def expect(obj, strict=None,
         # maybe if you need to ensure that `dog.bark()` was called at all
         verifyNoUnwantedInteractions()
 
-        # If the lower bound of between is set to 0, expect behaves similar
-        to lenient from Java mockito. I.e. verifyStubbedInvocationsAreUsed
-        passes even if stubbed function is not called in test.
+    If the lower bound of ``between`` is set to 0, :func:`expect`
+    behaves similar to lenient from Java Mockito.
+    I.e. :func:`verifyStubbedInvocationsAreUsed` passes even if
+    stubbed function is not called in test::
+
+        # We set our expectation
+        expect('os.path', between=(0, 3)).exists("/path").thenReturn(True)
+
+        # No call to os.path.exists happens here
+
+        verifyStubbedInvocationsAreUsed() # This passes
 
     .. note:: You must :func:`unstub` after stubbing, or use `with`
         statement.

--- a/tests/when_interface_test.py
+++ b/tests/when_interface_test.py
@@ -1,7 +1,8 @@
 
 import pytest
 
-from mockito import when, when2, expect, verify, patch, mock, spy2, verifyNoUnwantedInteractions
+from mockito import (when, when2, expect, verify, patch, mock, spy2,
+                     verifyNoUnwantedInteractions)
 from mockito.invocation import InvocationError
 
 class Dog(object):

--- a/tests/when_interface_test.py
+++ b/tests/when_interface_test.py
@@ -1,7 +1,7 @@
 
 import pytest
 
-from mockito import when, when2, expect, verify, patch, mock, spy2
+from mockito import when, when2, expect, verify, patch, mock, spy2, verifyNoUnwantedInteractions
 from mockito.invocation import InvocationError
 
 class Dog(object):
@@ -114,6 +114,14 @@ class TestDottedPaths:
 
         import os.path
         assert os.path.exists('/Foo')
+
+    def testExpect(self):
+        expect('os.path', times=2).exists('/Foo').thenReturn(True)
+
+        import os.path
+        os.path.exists('/Foo')
+        assert os.path.exists('/Foo')
+        verifyNoUnwantedInteractions()
 
     def testPatch(self):
         dummy = mock()


### PR DESCRIPTION
- [x] Updates `expect` to support dotted paths similar to when
- [ ] ~~Updates docs for devs that may search for an equivalent of lenient behaviour from Java Mockito~~

Ref #77 