### PR TITLE
Avoid partial when constructing answers

### DIFF
--- a/mockito/invocation.py
+++ b/mockito/invocation.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import functools
 import inspect
 import operator
 from collections import deque
@@ -407,10 +406,14 @@ class StubbedInvocation(MatchingInvocation):
 
 
 def return_(value, *a, **kw):
-    return value
+    def answer(*a, **kw):
+        return value
+    return answer
 
 def raise_(exception, *a, **kw):
-    raise exception
+    def answer(*a, **kw):
+        raise exception
+    return answer
 
 
 def discard_self(function):
@@ -429,13 +432,13 @@ class AnswerSelector(object):
 
     def thenReturn(self, *return_values):
         for return_value in return_values:
-            answer = functools.partial(return_, return_value)
+            answer = return_(return_value)
             self.__then(answer)
         return self
 
     def thenRaise(self, *exceptions):
         for exception in exceptions:
-            answer = functools.partial(raise_, exception)
+            answer = raise_(exception)
             self.__then(answer)
         return self
 

--- a/tests/issue_82_test.py
+++ b/tests/issue_82_test.py
@@ -1,0 +1,12 @@
+import pytest
+from mockito import when
+
+from . import module
+
+
+@pytest.mark.usefixtures('unstub')
+class TestIssue82:
+    def testFunctionWithArgumentNamedValue(self):
+        when(module).send(value="test").thenReturn("nope")
+        assert module.send(value="test") == "nope"
+

--- a/tests/module.py
+++ b/tests/module.py
@@ -6,3 +6,7 @@ class Foo(object):
 
 def one_arg(arg):
     return arg
+
+
+def send(value):
+    return value


### PR DESCRIPTION
Fixes #82

`function.partial` is not curry in the sense that later invocations can
try to override the partial invcoation.  In this case the argument
`value` could be reused by a function with the same argument.

Likely I confused "currying" with python `partial`.