### PR TITLE
Turn _Dict into an identity map

### DIFF
--- a/mockito/mock_registry.py
+++ b/mockito/mock_registry.py
@@ -28,7 +28,7 @@ class MockRegistry:
     """
 
     def __init__(self):
-        self.mocks = _Dict()
+        self.mocks = IdentityMap()
 
     def register(self, obj, mock):
         self.mocks[obj] = mock
@@ -54,8 +54,7 @@ class MockRegistry:
 
 
 # We have this dict like because we want non-hashable items in our registry.
-# This is just enough to match the invoking code above. TBC
-class _Dict(object):
+class IdentityMap(object):
     def __init__(self):
         self._store = []
 
@@ -64,7 +63,7 @@ class _Dict(object):
         self._store.append((key, value))
 
     def remove(self, key):
-        self._store = [(k, v) for k, v in self._store if k != key]
+        self._store = [(k, v) for k, v in self._store if k is not key]
 
     def pop(self, key):
         rv = self.get(key)
@@ -76,7 +75,7 @@ class _Dict(object):
 
     def get(self, key, default=None):
         for k, value in self._store:
-            if k == key:
+            if k is key:
                 return value
         return default
 

--- a/tests/issue_86_test.py
+++ b/tests/issue_86_test.py
@@ -1,0 +1,27 @@
+import pytest
+from mockito import when
+
+
+class Data:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, other):
+        if isinstance(other, Data):
+            return self.name == other.name
+        return NotImplemented
+
+    def tell_name(self):
+        return self.name
+
+
+@pytest.mark.usefixtures('unstub')
+class TestIssue86:
+    def testValueObjectsAreTreatedByIdentity(self):
+        a = Data("Bob")
+        b = Data("Bob")
+        when(a).tell_name().thenReturn("Sarah")
+        when(b).tell_name().thenReturn("Mulder")
+        assert a.tell_name() == "Sarah"
+        assert b.tell_name() == "Mulder"
+

--- a/tests/my_dict_test.py
+++ b/tests/my_dict_test.py
@@ -1,62 +1,54 @@
 
-import pytest
-
-from mockito.mock_registry import _Dict
-from mockito.mocking import Mock
+from mockito.mock_registry import IdentityMap
 
 
-class TestCustomDictLike:
+class TestIdentityMap:
 
-    def testAssignKeyValuePair(self):
-        td = _Dict()
-        obj = {}
-        mock = Mock(None)
-
-        td[obj] = mock
+    def testSetItemIsImplemented(self):
+        td = IdentityMap()
+        key = object()
+        val = object()
+        td[key] = val
 
     def testGetValueForKey(self):
-        td = _Dict()
-        obj = {}
-        mock = Mock(None)
-        td[obj] = mock
+        td = IdentityMap()
+        key = object()
+        val = object()
+        td[key] = val
 
-        assert td.get(obj) == mock
+        assert td.get(key) == val
+        assert td.get(object(), 42) == 42
 
     def testReplaceValueForSameKey(self):
-        td = _Dict()
-        obj = {}
-        mock1 = Mock(None)
-        mock2 = Mock(None)
-        td[obj] = mock1
-        td[obj] = mock2
+        td = IdentityMap()
+        key = object()
+        mock1 = object()
+        mock2 = object()
+        td[key] = mock1
+        td[key] = mock2
 
-        assert td.pop(obj) == mock2
-        with pytest.raises(KeyError):
-            td.pop(obj)
+        assert td.values() == [mock2]
 
     def testPopKey(self):
-        td = _Dict()
-        obj = {}
-        mock = Mock(None)
-        td[obj] = mock
+        td = IdentityMap()
+        key = object()
+        val = object()
+        td[key] = val
 
-        assert td.pop(obj) == mock
-        assert td.get(obj) is None
-
-    def testIterValues(self):
-        td = _Dict()
-        obj = {}
-        mock = Mock(None)
-        td[obj] = mock
-
-        assert td.values() == [mock]
+        assert td.pop(key) == val
+        assert td.values() == []
 
     def testClear(self):
-        td = _Dict()
-        obj = {}
-        mock = Mock(None)
-        td[obj] = mock
+        td = IdentityMap()
+        key = object()
+        val = object()
+        td[key] = val
 
         td.clear()
-        assert td.get(obj) is None
+        assert td.values() == []
 
+    def testEqualityIsIgnored(self):
+        td = IdentityMap()
+        td[{"one", "two", "foo"}] = object()
+        td[{"one", "two", "foo"}] = object()
+        assert len(td.values()) == 2


### PR DESCRIPTION
Fixes #86

Note esp. that there is no dunder-method to overwrite the `is` operator,
unlike `__eq__`, so this seems a) safe for all possible objects, and b)
especially right for data objects that implement `__eq__`.